### PR TITLE
Extend Number of Available Channels on Eurotherm for #7026

### DIFF
--- a/release_notes/ReleaseNotes_Upcoming.md
+++ b/release_notes/ReleaseNotes_Upcoming.md
@@ -29,6 +29,7 @@ See [here](https://github.com/ISISComputingGroup/IBEX/wiki#instrument-informatio
 | [#6997](https://github.com/ISISComputingGroup/IBEX/issues/6997) | Minor | TC/Beckhoff | Fixed axes alias loading in the TwinCAT IOC |
 | [#7019](https://github.com/ISISComputingGroup/IBEX/issues/7019) | Minor | ORC | Fixed ORC program name - was previously invalid 
 | [#6989](https://github.com/ISISComputingGroup/IBEX/issues/6989) | Minor | MCLennan    | Fixed homing failing due to potential poll at wrong time. |
+| [#7026](https://github.com/ISISComputingGroup/IBEX/issues/7026) | Minor | Eurotherm    | Extend number of available channels to 10 |
 
 ### Reflectometry IOC
 


### PR DESCRIPTION
Update the ReleaseNotes.md to include changes made in [#7026](https://github.com/ISISComputingGroup/IBEX/issues/7026) to extend the number of channels from 7 to 10 for the [Eurotherm IOC](https://github.com/ISISComputingGroup/EPICS-ioc/pull/675) and update the [IOC system tests](https://github.com/ISISComputingGroup/EPICS-IOC_Test_Framework/pull/524) the reflect this.