### PR TITLE
Check for errors rather than any details

### DIFF
--- a/.github/workflows/project_board_checks.yml
+++ b/.github/workflows/project_board_checks.yml
@@ -12,5 +12,5 @@ jobs:
         run: |
           output=$(curl -s --location --fail https://dataweb2.isis.rl.ac.uk/projectboardchecks)
           echo $output | jq -r '.details[]'
-          echo $output | jq -er '.error_num == 0'
+          echo $output | jq -er 'isempty(.details[] | select(startswith("ERROR")))'
         shell: bash


### PR DESCRIPTION
Checks only for errors, now that we also have warnings that we don't want to treat as failures.

right now `error_num` and reported warnings/errors are inconsistent with each other but this will be fixed on automation end at some point - so we can't just trust `error_num` directly.